### PR TITLE
Fix midori support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ fixuppm2.sh, copy/paste this line into the terminal window on your device
 ````bash
 bash -c "$(curl -sL https://raw.githubusercontent.com/sdetweil/MagicMirror_scripts/master/fixuppm2.sh)"
 ````
+
+## Switch to the Midori browser
+Especially low powered devices like the Pi Zero W might struggle running MagicMirror with the Chromium browser. A simpler browser like Midori might be a good alternative in this case. To switch to using the Midori browser change the `MagicMirror/installers/mm.sh` file to include the `external_browser` variable like:
+````bash
+cd ~/MagicMirror
+export external_browser=midori
+DISPLAY=:0 npm start
+````bash

--- a/run-start.sh
+++ b/run-start.sh
@@ -130,7 +130,7 @@ else
       else
         if [ "$(which $external_browser)." !=  "." ]; then
           if [ "$external_browser" == "midori" ]; then
-            "$external_browser" --app=http://localhost:$port -e Fullscreen  >/dev/null 2>&1
+            "$external_browser" http://localhost:$port -e Fullscreen Navigationbar  >/dev/null 2>&1
           else
             echo "don't know how to launch $external_browser"
           fi


### PR DESCRIPTION
With the help of #55 I figured out how to switch to using Midori to show MagicMirror as a Pi Zero seems a bit slow for Chromium.
Out of the box Midori was not working properly for me. First it did not show the URL at all then not in fullscreen, finally with a navbar.
These changes helped me fix that. If someone can confirm these changes they might be a good addition for this awesome project